### PR TITLE
Upgrade Apache Commons Collections

### DIFF
--- a/purchasenear/pom.xml
+++ b/purchasenear/pom.xml
@@ -27,8 +27,8 @@
         <commons-fileupload.version>1.3</commons-fileupload.version>
         <commons-beanutils.version>1.8.3</commons-beanutils.version>
         <commons-configuration.version>1.10</commons-configuration.version>
-        <commons-collections4.version>4.0</commons-collections4.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections4.version>4.1</commons-collections4.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-email.version>1.3.2</commons-email.version>
         <guava.version>14.0.1</guava.version>
         <mybatis.version>3.3.0</mybatis.version>


### PR DESCRIPTION
Version 3.2.1 and 4.0 have a CVSS 10.0 vulnerability. That's the worst kind
of vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/